### PR TITLE
Fixed SEVIR dataset download error

### DIFF
--- a/scripts/datasets/sevir/download_sevir.py
+++ b/scripts/datasets/sevir/download_sevir.py
@@ -1,5 +1,5 @@
 import argparse
-from earthformer.datasets.sevir.sevir_torch_wrap import download_SEVIR, download_SEVIR_LR
+from earthformer.datasets.sevir.sevir_torch_wrap import download_SEVIR
 
 
 def get_parser():

--- a/src/earthformer/datasets/sevir/sevir_torch_wrap.py
+++ b/src/earthformer/datasets/sevir/sevir_torch_wrap.py
@@ -114,10 +114,22 @@ class SEVIRTorchDataset(TorchDataset):
             num_workers=num_workers)
         return dataloader
 
+
+def check_aws():
+    r"""
+    Check if aws cli is installed.
+    """
+    if os.system("which aws") != 0:
+        raise RuntimeError("AWS CLI is not installed! Please install it first. See https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html")
+
+
 def download_SEVIR(save_dir=None):
     r"""
     Downloaded dataset is saved in save_dir/sevir
     """
+
+    check_aws()
+
     if save_dir is None:
         save_dir = cfg.datasets_dir
     sevir_dir = os.path.join(save_dir, "sevir")


### PR DESCRIPTION
This PR fixes the SEVIR dataset download error:

- Remove `download_SEVIR_LR` from the import as it does not exist in the code. Otherwise, it will throw an error when running the script.
- Add the `check_aww()` to check whether AWS CLI has been installed and prompts users to install it if necessary. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
