### PR TITLE
Update for loading pretrained checkpoints

### DIFF
--- a/scripts/cuboid_transformer/earthnet_w_meso/README.md
+++ b/scripts/cuboid_transformer/earthnet_w_meso/README.md
@@ -8,7 +8,7 @@ MASTER_ADDR=localhost MASTER_PORT=10001 python ./scripts/cuboid_transformer/eart
 Or run the following command to directly load pretrained checkpoint for test.
 ```bash
 cd ROOT_DIR/earth-forecasting-transformer
-MASTER_ADDR=localhost MASTER_PORT=10001 python ./scripts/cuboid_transformer/earthnet_w_meso/train_cuboid_earthnet.py --gpus 2 --cfg ./scripts/cuboid_transformer/earthnet_w_meso/earthformer_earthnet_v1.yaml --pretrained --save tmp_earthnet_w_meso
+MASTER_ADDR=localhost MASTER_PORT=10001 python ./scripts/cuboid_transformer/earthnet_w_meso/train_cuboid_earthnet.py --gpus 2 --pretrained --save tmp_earthnet_w_meso
 ```
 Run the tensorboard command to upload experiment records
 ```bash

--- a/scripts/cuboid_transformer/earthnet_w_meso/README.md
+++ b/scripts/cuboid_transformer/earthnet_w_meso/README.md
@@ -8,7 +8,7 @@ MASTER_ADDR=localhost MASTER_PORT=10001 python ./scripts/cuboid_transformer/eart
 Or run the following command to directly load pretrained checkpoint for test.
 ```bash
 cd ROOT_DIR/earth-forecasting-transformer
-MASTER_ADDR=localhost MASTER_PORT=10001 python ./scripts/cuboid_transformer/earthnet_w_meso/train_cuboid_earthnet.py --gpus 2 --cfg ./scripts/cuboid_transformer/earthnet_w_meso/cfg.yaml --pretrained --save tmp_earthnet_w_meso
+MASTER_ADDR=localhost MASTER_PORT=10001 python ./scripts/cuboid_transformer/earthnet_w_meso/train_cuboid_earthnet.py --gpus 2 --cfg ./scripts/cuboid_transformer/earthnet_w_meso/earthformer_earthnet_v1.yaml --pretrained --save tmp_earthnet_w_meso
 ```
 Run the tensorboard command to upload experiment records
 ```bash

--- a/scripts/cuboid_transformer/earthnet_w_meso/earthformer_earthnet_v1.yaml
+++ b/scripts/cuboid_transformer/earthnet_w_meso/earthformer_earthnet_v1.yaml
@@ -1,3 +1,4 @@
+# Configurations for pretrained checkpoint. Please do not modify it.
 dataset:
   return_mode: "default"
   data_aug_mode: null

--- a/scripts/cuboid_transformer/earthnet_w_meso/train_cuboid_earthnet.py
+++ b/scripts/cuboid_transformer/earthnet_w_meso/train_cuboid_earthnet.py
@@ -742,6 +742,8 @@ def get_parser():
 def main():
     parser = get_parser()
     args = parser.parse_args()
+    if args.pretrained:
+        args.cfg = os.path.abspath(os.path.join(os.path.dirname(__file__), "earthformer_earthnet_v1.yaml"))
     if args.cfg is not None:
         oc_from_file = OmegaConf.load(open(args.cfg, "r"))
         dataset_cfg = OmegaConf.to_object(oc_from_file.dataset)

--- a/scripts/cuboid_transformer/enso/README.md
+++ b/scripts/cuboid_transformer/enso/README.md
@@ -8,7 +8,7 @@ MASTER_ADDR=localhost MASTER_PORT=10001 python ./scripts/cuboid_transformer/enso
 Or run the following command to directly load pretrained checkpoint for test.
 ```bash
 cd ROOT_DIR/earth-forecasting-transformer
-MASTER_ADDR=localhost MASTER_PORT=10001 python ./scripts/cuboid_transformer/enso/train_cuboid_enso.py --gpus 2 --cfg ./scripts/cuboid_transformer/enso/earthformer_enso_v1.yaml --pretrained --save tmp_enso
+MASTER_ADDR=localhost MASTER_PORT=10001 python ./scripts/cuboid_transformer/enso/train_cuboid_enso.py --gpus 2 --pretrained --save tmp_enso
 ```
 Run the tensorboard command to upload experiment records
 ```bash

--- a/scripts/cuboid_transformer/enso/README.md
+++ b/scripts/cuboid_transformer/enso/README.md
@@ -8,7 +8,7 @@ MASTER_ADDR=localhost MASTER_PORT=10001 python ./scripts/cuboid_transformer/enso
 Or run the following command to directly load pretrained checkpoint for test.
 ```bash
 cd ROOT_DIR/earth-forecasting-transformer
-MASTER_ADDR=localhost MASTER_PORT=10001 python ./scripts/cuboid_transformer/enso/train_cuboid_enso.py --gpus 2 --cfg ./scripts/cuboid_transformer/enso/cfg.yaml --pretrained --save tmp_enso
+MASTER_ADDR=localhost MASTER_PORT=10001 python ./scripts/cuboid_transformer/enso/train_cuboid_enso.py --gpus 2 --cfg ./scripts/cuboid_transformer/enso/earthformer_enso_v1.yaml --pretrained --save tmp_enso
 ```
 Run the tensorboard command to upload experiment records
 ```bash

--- a/scripts/cuboid_transformer/enso/earthformer_enso_v1.yaml
+++ b/scripts/cuboid_transformer/enso/earthformer_enso_v1.yaml
@@ -1,3 +1,4 @@
+# Configurations for pretrained checkpoint. Please do not modify it.
 dataset:
   in_len: 12
   out_len: 14

--- a/scripts/cuboid_transformer/enso/train_cuboid_enso.py
+++ b/scripts/cuboid_transformer/enso/train_cuboid_enso.py
@@ -626,6 +626,8 @@ def get_parser():
 def main():
     parser = get_parser()
     args = parser.parse_args()
+    if args.pretrained:
+        args.cfg = os.path.abspath(os.path.join(os.path.dirname(__file__), "earthformer_enso_v1.yaml"))
     if args.cfg is not None:
         oc_from_file = OmegaConf.load(open(args.cfg, "r"))
         dataset_cfg = OmegaConf.to_object(oc_from_file.dataset)

--- a/scripts/cuboid_transformer/sevir/README.md
+++ b/scripts/cuboid_transformer/sevir/README.md
@@ -9,7 +9,7 @@ MASTER_ADDR=localhost MASTER_PORT=10001 python ./scripts/cuboid_transformer/sevi
 Or run the following command to directly load pretrained checkpoint for test.
 ```bash
 cd ROOT_DIR/earth-forecasting-transformer
-MASTER_ADDR=localhost MASTER_PORT=10001 python ./scripts/cuboid_transformer/sevir/train_cuboid_sevir.py --gpus 2 --cfg ./scripts/cuboid_transformer/sevir/cfg_sevir.yaml --pretrained --save tmp_sevir
+MASTER_ADDR=localhost MASTER_PORT=10001 python ./scripts/cuboid_transformer/sevir/train_cuboid_sevir.py --gpus 2 --cfg ./scripts/cuboid_transformer/sevir/earthformer_sevir_v1.yaml --pretrained --save tmp_sevir
 ```
 Run the tensorboard command to upload experiment records
 ```bash

--- a/scripts/cuboid_transformer/sevir/README.md
+++ b/scripts/cuboid_transformer/sevir/README.md
@@ -9,7 +9,7 @@ MASTER_ADDR=localhost MASTER_PORT=10001 python ./scripts/cuboid_transformer/sevi
 Or run the following command to directly load pretrained checkpoint for test.
 ```bash
 cd ROOT_DIR/earth-forecasting-transformer
-MASTER_ADDR=localhost MASTER_PORT=10001 python ./scripts/cuboid_transformer/sevir/train_cuboid_sevir.py --gpus 2 --cfg ./scripts/cuboid_transformer/sevir/earthformer_sevir_v1.yaml --pretrained --save tmp_sevir
+MASTER_ADDR=localhost MASTER_PORT=10001 python ./scripts/cuboid_transformer/sevir/train_cuboid_sevir.py --gpus 2 --pretrained --save tmp_sevir
 ```
 Run the tensorboard command to upload experiment records
 ```bash

--- a/scripts/cuboid_transformer/sevir/earthformer_sevir_v1.yaml
+++ b/scripts/cuboid_transformer/sevir/earthformer_sevir_v1.yaml
@@ -1,3 +1,4 @@
+# Configurations for pretrained checkpoint. Please do not modify it.
 dataset:
   dataset_name: "sevir"
   img_height: 384

--- a/scripts/cuboid_transformer/sevir/train_cuboid_sevir.py
+++ b/scripts/cuboid_transformer/sevir/train_cuboid_sevir.py
@@ -713,6 +713,8 @@ def get_parser():
 def main():
     parser = get_parser()
     args = parser.parse_args()
+    if args.pretrained:
+        args.cfg = os.path.abspath(os.path.join(os.path.dirname(__file__), "earthformer_sevir_v1.yaml"))
     if args.cfg is not None:
         oc_from_file = OmegaConf.load(open(args.cfg, "r"))
         dataset_oc = OmegaConf.to_object(oc_from_file.dataset)


### PR DESCRIPTION
Now users can run scripts for testing pretrained checkpoints without the need to specify the cfg.yaml files. The scripts load the correct cfgs for pretrained checkpoints automatically.
