### PR TITLE
Badges of results on EarthNet2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ## Earthformer
 
 [![PWC](https://img.shields.io/endpoint.svg?url=https://paperswithcode.com/badge/earthformer-exploring-space-time-transformers/weather-forecasting-on-sevir)](https://paperswithcode.com/sota/weather-forecasting-on-sevir?p=earthformer-exploring-space-time-transformers)
+[![PWC](https://img.shields.io/endpoint.svg?url=https://paperswithcode.com/badge/earthformer-exploring-space-time-transformers/earth-surface-forecasting-on-earthnet2021-iid)](https://paperswithcode.com/sota/earth-surface-forecasting-on-earthnet2021-iid?p=earthformer-exploring-space-time-transformers)
+[![PWC](https://img.shields.io/endpoint.svg?url=https://paperswithcode.com/badge/earthformer-exploring-space-time-transformers/earth-surface-forecasting-on-earthnet2021-ood)](https://paperswithcode.com/sota/earth-surface-forecasting-on-earthnet2021-ood?p=earthformer-exploring-space-time-transformers)
 
 By [Zhihan Gao](https://scholar.google.com/citations?user=P6ACUAUAAAAJ&hl=zh-CN), [Xingjian Shi](https://github.com/sxjscience), [Hao Wang](http://www.wanghao.in/), [Yi Zhu](https://bryanyzhu.github.io/), [Yuyang Wang](https://scholar.google.com/citations?user=IKUm624AAAAJ&hl=en), [Mu Li](https://github.com/mli), [Dit-Yan Yeung](https://scholar.google.com/citations?user=nEsOOx8AAAAJ&hl=en).
 


### PR DESCRIPTION
Copied the results of IID and OOD tracks on the official EarthNet2021 [leaderboard](https://www.earthnet.tech/docs/ch-leaderboard/) to https://paperswithcode.com/sota:

https://paperswithcode.com/sota/earth-surface-forecasting-on-earthnet2021-iid
https://paperswithcode.com/sota/earth-surface-forecasting-on-earthnet2021-ood

Updated the badges in [README](https://github.com/gaozhihan/earth-forecasting-transformer/blob/4b2db5414905e1561027b33b44db45d2a57ddda8/README.md?plain=1#L4-L5).


