### PR TITLE
Fix: exps_dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,11 @@ dmypy.json
 
 # experiment results
 /experiments/
+/scripts/cuboid_transformer/moving_mnist/experiments/
+/scripts/cuboid_transformer/nbody/experiments/
+/scripts/cuboid_transformer/sevir/experiments/
+/scripts/cuboid_transformer/enso/experiments/
+/scripts/cuboid_transformer/earthnet_w_meso/experiments/
 
 # local documents
 /docs/

--- a/scripts/cuboid_transformer/earthnet_w_meso/README.md
+++ b/scripts/cuboid_transformer/earthnet_w_meso/README.md
@@ -2,12 +2,12 @@
 Run the following command to train Earthformer on EarthNet2021 dataset. 
 Change the configurations in [cfg.yaml](./cfg.yaml)
 ```bash
-MASTER_ADDR=localhost MASTER_PORT=10001 python train_cuboid_earthnet.py --gpus 2 --cfg cfg.yaml --ckpt_name last.ckpt --save ./experiments/tmp_earthnet_w_meso
+MASTER_ADDR=localhost MASTER_PORT=10001 python train_cuboid_earthnet.py --gpus 2 --cfg cfg.yaml --ckpt_name last.ckpt --save tmp_earthnet_w_meso
 ```
 
 Or run the following command to directly load pretrained checkpoint for test.
 ```bash
-MASTER_ADDR=localhost MASTER_PORT=10001 python train_cuboid_earthnet.py --gpus 2 --pretrained --save ./experiments/tmp_earthnet_w_meso
+MASTER_ADDR=localhost MASTER_PORT=10001 python train_cuboid_earthnet.py --gpus 2 --pretrained --save tmp_earthnet_w_meso
 ```
 Run the tensorboard command to upload experiment records
 ```bash

--- a/scripts/cuboid_transformer/earthnet_w_meso/train_cuboid_earthnet.py
+++ b/scripts/cuboid_transformer/earthnet_w_meso/train_cuboid_earthnet.py
@@ -28,6 +28,9 @@ from earthformer.datasets.earthnet.visualization import vis_earthnet_seq
 from earthformer.utils.apex_ddp import ApexDDPPlugin
 
 
+_curr_dir = os.path.realpath(os.path.dirname(os.path.realpath(__file__)))
+exps_dir = os.path.join(_curr_dir, "experiments")
+pretrained_checkpoints_dir = cfg.pretrained_checkpoints_dir
 pytorch_state_dict_name = "earthformer_earthnet2021.pt"
 
 class CuboidEarthNet2021PLModule(pl.LightningModule):
@@ -168,7 +171,7 @@ class CuboidEarthNet2021PLModule(pl.LightningModule):
         self.configure_save(cfg_file_path=oc_file)
 
     def configure_save(self, cfg_file_path=None):
-        self.save_dir = os.path.join(cfg.exps_dir, self.save_dir)
+        self.save_dir = os.path.join(exps_dir, self.save_dir)
         os.makedirs(self.save_dir, exist_ok=True)
         self.scores_dir = os.path.join(self.save_dir, 'scores')
         os.makedirs(self.scores_dir, exist_ok=True)
@@ -780,11 +783,11 @@ def main():
     trainer = Trainer(**trainer_kwargs)
     if args.pretrained:
         pretrained_ckpt_name = pytorch_state_dict_name
-        if not os.path.exists(os.path.join(cfg.pretrained_checkpoints_dir, pretrained_ckpt_name)):
+        if not os.path.exists(os.path.join(pretrained_checkpoints_dir, pretrained_ckpt_name)):
             s3_download_pretrained_ckpt(ckpt_name=pretrained_ckpt_name,
-                                        save_dir=cfg.pretrained_checkpoints_dir,
+                                        save_dir=pretrained_checkpoints_dir,
                                         exist_ok=False)
-        state_dict = torch.load(os.path.join(cfg.pretrained_checkpoints_dir, pretrained_ckpt_name),
+        state_dict = torch.load(os.path.join(pretrained_checkpoints_dir, pretrained_ckpt_name),
                                 map_location=torch.device("cpu"))
         pl_module.torch_nn_module.load_state_dict(state_dict=state_dict)
         for test_dataloader in dataloader_dict["test_dataloader"]:

--- a/scripts/cuboid_transformer/enso/README.md
+++ b/scripts/cuboid_transformer/enso/README.md
@@ -3,12 +3,12 @@ Run the following command to train Earthformer on ICAR-ENSO dataset.
 Change the configurations in [cfg.yaml](./cfg.yaml)
 ```bash
 cd ROOT_DIR/earth-forecasting-transformer
-MASTER_ADDR=localhost MASTER_PORT=10001 python ./scripts/cuboid_transformer/enso/train_cuboid_enso.py --gpus 2 --cfg ./scripts/cuboid_transformer/enso/cfg.yaml --ckpt_name last.ckpt --save tmp_enso
+MASTER_ADDR=localhost MASTER_PORT=10001 python train_cuboid_enso.py --gpus 2 --cfg cfg.yaml --ckpt_name last.ckpt --save tmp_enso
 ```
 Or run the following command to directly load pretrained checkpoint for test.
 ```bash
 cd ROOT_DIR/earth-forecasting-transformer
-MASTER_ADDR=localhost MASTER_PORT=10001 python ./scripts/cuboid_transformer/enso/train_cuboid_enso.py --gpus 2 --pretrained --save tmp_enso
+MASTER_ADDR=localhost MASTER_PORT=10001 python train_cuboid_enso.py --gpus 2 --pretrained --save tmp_enso
 ```
 Run the tensorboard command to upload experiment records
 ```bash

--- a/scripts/cuboid_transformer/enso/README.md
+++ b/scripts/cuboid_transformer/enso/README.md
@@ -2,16 +2,13 @@
 Run the following command to train Earthformer on ICAR-ENSO dataset. 
 Change the configurations in [cfg.yaml](./cfg.yaml)
 ```bash
-cd ROOT_DIR/earth-forecasting-transformer
 MASTER_ADDR=localhost MASTER_PORT=10001 python train_cuboid_enso.py --gpus 2 --cfg cfg.yaml --ckpt_name last.ckpt --save tmp_enso
 ```
 Or run the following command to directly load pretrained checkpoint for test.
 ```bash
-cd ROOT_DIR/earth-forecasting-transformer
 MASTER_ADDR=localhost MASTER_PORT=10001 python train_cuboid_enso.py --gpus 2 --pretrained --save tmp_enso
 ```
 Run the tensorboard command to upload experiment records
 ```bash
-cd ROOT_DIR/earth-forecasting-transformer
 tensorboard dev upload --logdir ./experiments/tmp_enso/lightning_logs --name 'tmp_enso'
 ```

--- a/scripts/cuboid_transformer/enso/train_cuboid_enso.py
+++ b/scripts/cuboid_transformer/enso/train_cuboid_enso.py
@@ -26,6 +26,9 @@ from earthformer.metrics.enso import sst_to_nino, compute_enso_score
 from earthformer.utils.apex_ddp import ApexDDPPlugin
 
 
+_curr_dir = os.path.realpath(os.path.dirname(os.path.realpath(__file__)))
+exps_dir = os.path.join(_curr_dir, "experiments")
+pretrained_checkpoints_dir = cfg.pretrained_checkpoints_dir
 pytorch_state_dict_name = "earthformer_icarenso2021.pt"
 
 class CuboidENSOPLModule(pl.LightningModule):
@@ -156,7 +159,7 @@ class CuboidENSOPLModule(pl.LightningModule):
         self.configure_save(cfg_file_path=oc_file)
 
     def configure_save(self, cfg_file_path=None):
-        self.save_dir = os.path.join(cfg.exps_dir, self.save_dir)
+        self.save_dir = os.path.join(exps_dir, self.save_dir)
         os.makedirs(self.save_dir, exist_ok=True)
         self.scores_dir = os.path.join(self.save_dir, 'scores')
         os.makedirs(self.scores_dir, exist_ok=True)
@@ -665,11 +668,11 @@ def main():
     trainer = Trainer(**trainer_kwargs)
     if args.pretrained:
         pretrained_ckpt_name = pytorch_state_dict_name
-        if not os.path.exists(os.path.join(cfg.pretrained_checkpoints_dir, pretrained_ckpt_name)):
+        if not os.path.exists(os.path.join(pretrained_checkpoints_dir, pretrained_ckpt_name)):
             s3_download_pretrained_ckpt(ckpt_name=pretrained_ckpt_name,
-                                        save_dir=cfg.pretrained_checkpoints_dir,
+                                        save_dir=pretrained_checkpoints_dir,
                                         exist_ok=False)
-        state_dict = torch.load(os.path.join(cfg.pretrained_checkpoints_dir, pretrained_ckpt_name),
+        state_dict = torch.load(os.path.join(pretrained_checkpoints_dir, pretrained_ckpt_name),
                                 map_location=torch.device("cpu"))
         pl_module.torch_nn_module.load_state_dict(state_dict=state_dict)
         trainer.test(model=pl_module,

--- a/scripts/cuboid_transformer/moving_mnist/README.md
+++ b/scripts/cuboid_transformer/moving_mnist/README.md
@@ -3,7 +3,7 @@ Run the following command to train Earthformer on Moving MNIST dataset.
 Change the configurations in [cfg.yaml](./cfg.yaml)
 ```bash
 cd ROOT_DIR/earth-forecasting-transformer
-MASTER_ADDR=localhost MASTER_PORT=10001 python ./scripts/cuboid_transformer/moving_mnist/train_cuboid_mnist.py --gpus 2 --cfg ./scripts/cuboid_transformer/moving_mnist/cfg.yaml --ckpt_name last.ckpt --save tmp_mnist
+MASTER_ADDR=localhost MASTER_PORT=10001 python train_cuboid_mnist.py --gpus 2 --cfg cfg.yaml --ckpt_name last.ckpt --save tmp_mnist
 ```
 Run the tensorboard command to upload experiment records
 ```bash

--- a/scripts/cuboid_transformer/moving_mnist/README.md
+++ b/scripts/cuboid_transformer/moving_mnist/README.md
@@ -2,11 +2,9 @@
 Run the following command to train Earthformer on Moving MNIST dataset. 
 Change the configurations in [cfg.yaml](./cfg.yaml)
 ```bash
-cd ROOT_DIR/earth-forecasting-transformer
 MASTER_ADDR=localhost MASTER_PORT=10001 python train_cuboid_mnist.py --gpus 2 --cfg cfg.yaml --ckpt_name last.ckpt --save tmp_mnist
 ```
 Run the tensorboard command to upload experiment records
 ```bash
-cd ROOT_DIR/earth-forecasting-transformer
 tensorboard dev upload --logdir ./experiments/tmp_mnist/lightning_logs --name 'tmp_mnist'
 ```

--- a/scripts/cuboid_transformer/moving_mnist/train_cuboid_mnist.py
+++ b/scripts/cuboid_transformer/moving_mnist/train_cuboid_mnist.py
@@ -26,6 +26,9 @@ from earthformer.datasets.moving_mnist.moving_mnist import MovingMNISTDataModule
 from earthformer.utils.apex_ddp import ApexDDPPlugin
 
 
+_curr_dir = os.path.realpath(os.path.dirname(os.path.realpath(__file__)))
+exps_dir = os.path.join(_curr_dir, "experiments")
+
 class CuboidMovingMNISTPLModule(pl.LightningModule):
 
     def __init__(self,
@@ -152,7 +155,7 @@ class CuboidMovingMNISTPLModule(pl.LightningModule):
         self.test_ssim = torchmetrics.StructuralSimilarityIndexMeasure()
 
     def configure_save(self, cfg_file_path=None):
-        self.save_dir = os.path.join(cfg.exps_dir, self.save_dir)
+        self.save_dir = os.path.join(exps_dir, self.save_dir)
         os.makedirs(self.save_dir, exist_ok=True)
         self.scores_dir = os.path.join(self.save_dir, 'scores')
         os.makedirs(self.scores_dir, exist_ok=True)

--- a/scripts/cuboid_transformer/nbody/README.md
+++ b/scripts/cuboid_transformer/nbody/README.md
@@ -2,11 +2,9 @@
 Run the following command to train Earthformer on N-body MNIST dataset. 
 Change the configurations in [cfg.yaml](./cfg.yaml)
 ```bash
-cd ROOT_DIR/earth-forecasting-transformer
 MASTER_ADDR=localhost MASTER_PORT=10001 python train_cuboid_nbody.py --gpus 2 --cfg cfg.yaml --ckpt_name last.ckpt --save tmp_nbody
 ```
 Run the tensorboard command to upload experiment records
 ```bash
-cd ROOT_DIR/earth-forecasting-transformer
 tensorboard dev upload --logdir ./experiments/tmp_nbody/lightning_logs --name 'tmp_nbody'
 ```

--- a/scripts/cuboid_transformer/nbody/README.md
+++ b/scripts/cuboid_transformer/nbody/README.md
@@ -3,7 +3,7 @@ Run the following command to train Earthformer on N-body MNIST dataset.
 Change the configurations in [cfg.yaml](./cfg.yaml)
 ```bash
 cd ROOT_DIR/earth-forecasting-transformer
-MASTER_ADDR=localhost MASTER_PORT=10001 python ./scripts/cuboid_transformer/nbody/train_cuboid_nbody.py --gpus 2 --cfg ./scripts/cuboid_transformer/nbody/cfg.yaml --ckpt_name last.ckpt --save tmp_nbody
+MASTER_ADDR=localhost MASTER_PORT=10001 python train_cuboid_nbody.py --gpus 2 --cfg cfg.yaml --ckpt_name last.ckpt --save tmp_nbody
 ```
 Run the tensorboard command to upload experiment records
 ```bash

--- a/scripts/cuboid_transformer/nbody/train_cuboid_nbody.py
+++ b/scripts/cuboid_transformer/nbody/train_cuboid_nbody.py
@@ -26,6 +26,9 @@ from earthformer.datasets.nbody.nbody_mnist_torch_wrap import NBodyMovingMNISTLi
 from earthformer.utils.apex_ddp import ApexDDPPlugin
 
 
+_curr_dir = os.path.realpath(os.path.dirname(os.path.realpath(__file__)))
+exps_dir = os.path.join(_curr_dir, "experiments")
+
 class CuboidNBodyPLModule(pl.LightningModule):
 
     def __init__(self,
@@ -152,7 +155,7 @@ class CuboidNBodyPLModule(pl.LightningModule):
         self.test_ssim = torchmetrics.StructuralSimilarityIndexMeasure()
 
     def configure_save(self, cfg_file_path=None):
-        self.save_dir = os.path.join(cfg.exps_dir, self.save_dir)
+        self.save_dir = os.path.join(exps_dir, self.save_dir)
         os.makedirs(self.save_dir, exist_ok=True)
         self.scores_dir = os.path.join(self.save_dir, 'scores')
         os.makedirs(self.scores_dir, exist_ok=True)

--- a/scripts/cuboid_transformer/sevir/README.md
+++ b/scripts/cuboid_transformer/sevir/README.md
@@ -3,28 +3,23 @@
 Run the following command to train Earthformer on SEVIR dataset. 
 Change the configurations in [cfg_sevir.yaml](./cfg_sevir.yaml)
 ```bash
-cd ROOT_DIR/earth-forecasting-transformer
 MASTER_ADDR=localhost MASTER_PORT=10001 python train_cuboid_sevir.py --gpus 2 --cfg cfg_sevir.yaml --ckpt_name last.ckpt --save tmp_sevir
 ```
 Or run the following command to directly load pretrained checkpoint for test.
 ```bash
-cd ROOT_DIR/earth-forecasting-transformer
 MASTER_ADDR=localhost MASTER_PORT=10001 python train_cuboid_sevir.py --gpus 2 --pretrained --save tmp_sevir
 ```
 Run the tensorboard command to upload experiment records
 ```bash
-cd ROOT_DIR/earth-forecasting-transformer
 tensorboard dev upload --logdir ./experiments/tmp_sevir/lightning_logs --name 'tmp_sevir'
 ```
 ## SEVIR-LR
 Run the following command to train Earthformer on SEVIR-LR dataset. 
 Change the configurations in [cfg_sevirlr.yaml](./cfg_sevirlr.yaml)
 ```bash
-cd ROOT_DIR/earth-forecasting-transformer
 MASTER_ADDR=localhost MASTER_PORT=10001 python train_cuboid_sevir.py --gpus 2 --cfg cfg_sevirlr.yaml --ckpt_name last.ckpt --save tmp_sevirlr
 ```
 Run the tensorboard command to upload experiment records
 ```bash
-cd ROOT_DIR/earth-forecasting-transformer
 tensorboard dev upload --logdir ./experiments/tmp_sevirlr/lightning_logs --name 'tmp_sevirlr'
 ```

--- a/scripts/cuboid_transformer/sevir/README.md
+++ b/scripts/cuboid_transformer/sevir/README.md
@@ -4,12 +4,12 @@ Run the following command to train Earthformer on SEVIR dataset.
 Change the configurations in [cfg_sevir.yaml](./cfg_sevir.yaml)
 ```bash
 cd ROOT_DIR/earth-forecasting-transformer
-MASTER_ADDR=localhost MASTER_PORT=10001 python ./scripts/cuboid_transformer/sevir/train_cuboid_sevir.py --gpus 2 --cfg ./scripts/cuboid_transformer/sevir/cfg_sevir.yaml --ckpt_name last.ckpt --save tmp_sevir
+MASTER_ADDR=localhost MASTER_PORT=10001 python train_cuboid_sevir.py --gpus 2 --cfg cfg_sevir.yaml --ckpt_name last.ckpt --save tmp_sevir
 ```
 Or run the following command to directly load pretrained checkpoint for test.
 ```bash
 cd ROOT_DIR/earth-forecasting-transformer
-MASTER_ADDR=localhost MASTER_PORT=10001 python ./scripts/cuboid_transformer/sevir/train_cuboid_sevir.py --gpus 2 --pretrained --save tmp_sevir
+MASTER_ADDR=localhost MASTER_PORT=10001 python train_cuboid_sevir.py --gpus 2 --pretrained --save tmp_sevir
 ```
 Run the tensorboard command to upload experiment records
 ```bash
@@ -21,7 +21,7 @@ Run the following command to train Earthformer on SEVIR-LR dataset.
 Change the configurations in [cfg_sevirlr.yaml](./cfg_sevirlr.yaml)
 ```bash
 cd ROOT_DIR/earth-forecasting-transformer
-MASTER_ADDR=localhost MASTER_PORT=10001 python ./scripts/cuboid_transformer/sevir/train_cuboid_sevir.py --gpus 2 --cfg ./scripts/cuboid_transformer/sevir/cfg_sevirlr.yaml --ckpt_name last.ckpt --save tmp_sevirlr
+MASTER_ADDR=localhost MASTER_PORT=10001 python train_cuboid_sevir.py --gpus 2 --cfg cfg_sevirlr.yaml --ckpt_name last.ckpt --save tmp_sevirlr
 ```
 Run the tensorboard command to upload experiment records
 ```bash

--- a/scripts/cuboid_transformer/sevir/train_cuboid_sevir.py
+++ b/scripts/cuboid_transformer/sevir/train_cuboid_sevir.py
@@ -31,6 +31,9 @@ from earthformer.datasets.sevir.sevir_torch_wrap import SEVIRLightningDataModule
 from earthformer.utils.apex_ddp import ApexDDPPlugin
 
 
+_curr_dir = os.path.realpath(os.path.dirname(os.path.realpath(__file__)))
+exps_dir = os.path.join(_curr_dir, "experiments")
+pretrained_checkpoints_dir = cfg.pretrained_checkpoints_dir
 pytorch_state_dict_name = "earthformer_sevir.pt"
 
 class CuboidSEVIRPLModule(pl.LightningModule):
@@ -175,7 +178,7 @@ class CuboidSEVIRPLModule(pl.LightningModule):
             eps=1e-4,)
 
     def configure_save(self, cfg_file_path=None):
-        self.save_dir = os.path.join(cfg.exps_dir, self.save_dir)
+        self.save_dir = os.path.join(exps_dir, self.save_dir)
         os.makedirs(self.save_dir, exist_ok=True)
         self.scores_dir = os.path.join(self.save_dir, 'scores')
         os.makedirs(self.scores_dir, exist_ok=True)
@@ -752,11 +755,11 @@ def main():
     trainer = Trainer(**trainer_kwargs)
     if args.pretrained:
         pretrained_ckpt_name = pytorch_state_dict_name
-        if not os.path.exists(os.path.join(cfg.pretrained_checkpoints_dir, pretrained_ckpt_name)):
+        if not os.path.exists(os.path.join(pretrained_checkpoints_dir, pretrained_ckpt_name)):
             s3_download_pretrained_ckpt(ckpt_name=pretrained_ckpt_name,
-                                        save_dir=cfg.pretrained_checkpoints_dir,
+                                        save_dir=pretrained_checkpoints_dir,
                                         exist_ok=False)
-        state_dict = torch.load(os.path.join(cfg.pretrained_checkpoints_dir, pretrained_ckpt_name),
+        state_dict = torch.load(os.path.join(pretrained_checkpoints_dir, pretrained_ckpt_name),
                                 map_location=torch.device("cpu"))
         pl_module.torch_nn_module.load_state_dict(state_dict=state_dict)
         trainer.test(model=pl_module,


### PR DESCRIPTION
1. Change the dir for saving experiment results from `PROJECT_ROOT/experiments/` to separate dir for each dataset. E.g., `PROJECT_ROOT/scripts/cuboid_transformer/sevir/experiments/` is for saving experiments on SEVIR dataset.
2. Delete the usage of `cfg` from `from earthformer.config import cfg` in all training scripts, except for setting the `pretrained_checkpoints_dir` at very beginning, like in https://github.com/gaozhihan/earth-forecasting-transformer/blob/5fb63264c5f241add4b75fd544e7dd78bcc5b401/scripts/cuboid_transformer/earthnet_w_meso/train_cuboid_earthnet.py#L33.
3. Modify the `README`s for the training scripts accordingly.
4. Add separate experiment dirs to `.gitignore`.

