### PR TITLE
refactor: use DDPStrategy instead of DDPPlugin

### DIFF
--- a/scripts/baselines/persistence/earthnet/test_persistence_earthnet.py
+++ b/scripts/baselines/persistence/earthnet/test_persistence_earthnet.py
@@ -21,7 +21,7 @@ from earthformer.baselines.persistence import Persistence
 from earthformer.datasets.earthnet.earthnet_dataloader import EarthNet2021LightningDataModule, get_EarthNet2021_dataloaders
 from earthformer.datasets.earthnet.earthnet_scores import EarthNet2021ScoreUpdateWithoutCompute
 from earthformer.datasets.earthnet.visualization import vis_earthnet_seq
-from earthformer.utils.apex_ddp import ApexDDPPlugin
+from earthformer.utils.apex_ddp import ApexDDPStrategy
 
 
 class PersistenceEarthNet2021PLModule(pl.LightningModule):
@@ -178,7 +178,7 @@ class PersistenceEarthNet2021PLModule(pl.LightningModule):
             # ddp
             accelerator="gpu",
             # strategy="ddp",
-            strategy=ApexDDPPlugin(find_unused_parameters=False, delay_allreduce=True),
+            strategy=ApexDDPStrategy(find_unused_parameters=False, delay_allreduce=True),
             # optimization
             max_epochs=1,
             check_val_every_n_epoch=1,

--- a/scripts/cuboid_transformer/earthnet_w_meso/train_cuboid_earthnet.py
+++ b/scripts/cuboid_transformer/earthnet_w_meso/train_cuboid_earthnet.py
@@ -25,7 +25,7 @@ from earthformer.cuboid_transformer.cuboid_transformer_unet_dec import CuboidTra
 from earthformer.datasets.earthnet.earthnet_dataloader import EarthNet2021LightningDataModule, get_EarthNet2021_dataloaders
 from earthformer.datasets.earthnet.earthnet_scores import EarthNet2021ScoreUpdateWithoutCompute
 from earthformer.datasets.earthnet.visualization import vis_earthnet_seq
-from earthformer.utils.apex_ddp import ApexDDPPlugin
+from earthformer.utils.apex_ddp import ApexDDPStrategy
 
 
 _curr_dir = os.path.realpath(os.path.dirname(os.path.realpath(__file__)))
@@ -442,7 +442,7 @@ class CuboidEarthNet2021PLModule(pl.LightningModule):
             # ddp
             accelerator="gpu",
             # strategy="ddp",
-            strategy=ApexDDPPlugin(find_unused_parameters=False, delay_allreduce=True),
+            strategy=ApexDDPStrategy(find_unused_parameters=False, delay_allreduce=True),
             # optimization
             max_epochs=self.oc.optim.max_epochs,
             check_val_every_n_epoch=self.oc.trainer.check_val_every_n_epoch,

--- a/scripts/cuboid_transformer/enso/train_cuboid_enso.py
+++ b/scripts/cuboid_transformer/enso/train_cuboid_enso.py
@@ -23,7 +23,7 @@ from earthformer.utils.checkpoint import pl_ckpt_to_pytorch_state_dict, s3_downl
 from earthformer.cuboid_transformer.cuboid_transformer import CuboidTransformerModel
 from earthformer.datasets.enso.enso_dataloader import ENSOLightningDataModule, NINO_WINDOW_T
 from earthformer.metrics.enso import sst_to_nino, compute_enso_score
-from earthformer.utils.apex_ddp import ApexDDPPlugin
+from earthformer.utils.apex_ddp import ApexDDPStrategy
 
 
 _curr_dir = os.path.realpath(os.path.dirname(os.path.realpath(__file__)))
@@ -413,7 +413,7 @@ class CuboidENSOPLModule(pl.LightningModule):
             # ddp
             accelerator="gpu",
             # strategy="ddp",
-            strategy=ApexDDPPlugin(find_unused_parameters=False, delay_allreduce=True),
+            strategy=ApexDDPStrategy(find_unused_parameters=False, delay_allreduce=True),
             # optimization
             max_epochs=self.oc.optim.max_epochs,
             check_val_every_n_epoch=self.oc.trainer.check_val_every_n_epoch,

--- a/scripts/cuboid_transformer/moving_mnist/train_cuboid_mnist.py
+++ b/scripts/cuboid_transformer/moving_mnist/train_cuboid_mnist.py
@@ -23,7 +23,7 @@ from earthformer.utils.layout import layout_to_in_out_slice
 from earthformer.visualization.nbody import save_example_vis_results
 from earthformer.cuboid_transformer.cuboid_transformer import CuboidTransformerModel
 from earthformer.datasets.moving_mnist.moving_mnist import MovingMNISTDataModule
-from earthformer.utils.apex_ddp import ApexDDPPlugin
+from earthformer.utils.apex_ddp import ApexDDPStrategy
 
 
 _curr_dir = os.path.realpath(os.path.dirname(os.path.realpath(__file__)))
@@ -396,7 +396,7 @@ class CuboidMovingMNISTPLModule(pl.LightningModule):
             # ddp
             accelerator="gpu",
             # strategy="ddp",
-            strategy=ApexDDPPlugin(find_unused_parameters=False, delay_allreduce=True),
+            strategy=ApexDDPStrategy(find_unused_parameters=False, delay_allreduce=True),
             # optimization
             max_epochs=self.oc.optim.max_epochs,
             check_val_every_n_epoch=self.oc.trainer.check_val_every_n_epoch,

--- a/scripts/cuboid_transformer/nbody/train_cuboid_nbody.py
+++ b/scripts/cuboid_transformer/nbody/train_cuboid_nbody.py
@@ -23,7 +23,7 @@ from earthformer.utils.layout import layout_to_in_out_slice
 from earthformer.visualization.nbody import save_example_vis_results
 from earthformer.cuboid_transformer.cuboid_transformer import CuboidTransformerModel
 from earthformer.datasets.nbody.nbody_mnist_torch_wrap import NBodyMovingMNISTLightningDataModule
-from earthformer.utils.apex_ddp import ApexDDPPlugin
+from earthformer.utils.apex_ddp import ApexDDPStrategy
 
 
 _curr_dir = os.path.realpath(os.path.dirname(os.path.realpath(__file__)))
@@ -427,7 +427,7 @@ class CuboidNBodyPLModule(pl.LightningModule):
             # ddp
             accelerator="gpu",
             # strategy="ddp",
-            strategy=ApexDDPPlugin(find_unused_parameters=False, delay_allreduce=True),
+            strategy=ApexDDPStrategy(find_unused_parameters=False, delay_allreduce=True),
             # optimization
             max_epochs=self.oc.optim.max_epochs,
             check_val_every_n_epoch=self.oc.trainer.check_val_every_n_epoch,

--- a/scripts/cuboid_transformer/sevir/train_cuboid_sevir.py
+++ b/scripts/cuboid_transformer/sevir/train_cuboid_sevir.py
@@ -28,7 +28,7 @@ from earthformer.visualization.sevir.sevir_vis_seq import save_example_vis_resul
 from earthformer.metrics.sevir import SEVIRSkillScore
 from earthformer.cuboid_transformer.cuboid_transformer import CuboidTransformerModel
 from earthformer.datasets.sevir.sevir_torch_wrap import SEVIRLightningDataModule
-from earthformer.utils.apex_ddp import ApexDDPPlugin
+from earthformer.utils.apex_ddp import ApexDDPStrategy
 
 
 _curr_dir = os.path.realpath(os.path.dirname(os.path.realpath(__file__)))
@@ -450,7 +450,7 @@ class CuboidSEVIRPLModule(pl.LightningModule):
             # ddp
             accelerator="gpu",
             # strategy="ddp",
-            strategy=ApexDDPPlugin(find_unused_parameters=False, delay_allreduce=True),
+            strategy=ApexDDPStrategy(find_unused_parameters=False, delay_allreduce=True),
             # optimization
             max_epochs=self.oc.optim.max_epochs,
             check_val_every_n_epoch=self.oc.trainer.check_val_every_n_epoch,

--- a/src/earthformer/utils/apex_ddp.py
+++ b/src/earthformer/utils/apex_ddp.py
@@ -2,7 +2,7 @@
 # We will need to use the AMP implementation from apex because https://discuss.pytorch.org/t/using-torch-utils-checkpoint-checkpoint-with-dataparallel/78452
 
 from apex.parallel import DistributedDataParallel
-from pytorch_lightning.plugins.training_type import DDPPlugin
+from pytorch_lightning.strategies.ddp import DDPStrategy
 from pytorch_lightning.overrides.base import (
     _LightningModuleWrapperBase,
     _LightningPrecisionModuleWrapperBase,
@@ -19,7 +19,7 @@ def unwrap_lightning_module(wrapped_model):
     return model
 
 
-class ApexDDPPlugin(DDPPlugin):
+class ApexDDPStrategy(DDPStrategy):
     def _setup_model(self, model):
         return DistributedDataParallel(model, delay_allreduce=False)
 
@@ -33,5 +33,5 @@ if __name__ == "__main__":
     # when using `strategy="ddp"` in pl.
     import pytorch_lightning as pl
     trainer = pl.Trainer(
-        strategy=ApexDDPPlugin(find_unused_parameters=False, delay_allreduce=True),  # "ddp",
+        strategy=ApexDDPStrategy(find_unused_parameters=False, delay_allreduce=True),  # "ddp",
     )


### PR DESCRIPTION
Update the implementation of `ApexDDPPlugin` to inherit from `DDPStrategy` instead of `DDPPlugin` to avoid the following deprecation.

```
ENV_ROOT/lib/python3.9/site-packages/pytorch_lightning/plugins/training_type/ddp.py:20: LightningDeprecationWarning: The `pl.plugins.training_type.ddp.DDPPlugin` is deprecated in v1.6 and will be removed in v1.8. Use `pl.strategies.ddp.DDPStrategy` instead.
```
