### PR TITLE
Upload N-body MNIST dataset used in the Earthformer paper to AWS S3 + support downloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,13 @@ $\frac{d^2\boldsymbol{x}\_{i}}{dt^2} = - \sum\_{j\neq i}\frac{G m\_j (\boldsymbo
 
 where $\boldsymbol{x}\_{i}$ is the spatial coordinates of the $i$-th digit, $G$ is the gravitational constant, $m\_j$ is the mass of the $j$-th digit, $r$ is a constant representing the power scale in the gravitational law, $d\_{\text{soft}}$ is a small softening distance that ensures numerical stability.
 
-Run the following commands to generate N-body MNIST dataset.
+To download the N-body MNIST dataset used in our paper from AWS S3 run:
+```bash
+cd ROOT_DIR/earth-forecasting-transformer
+python ./scripts/datasets/nbody/download_nbody_paper.py
+```
+
+Alternatively, run the following commands to generate N-body MNIST dataset.
 ```bash
 cd ROOT_DIR/earth-forecasting-transformer
 python ./scripts/datasets/nbody/generate_nbody_dataset.py --cfg ./scripts/datasets/nbody/cfg.yaml

--- a/scripts/datasets/nbody/download_nbody_paper.py
+++ b/scripts/datasets/nbody/download_nbody_paper.py
@@ -1,0 +1,22 @@
+import warnings
+import os
+
+
+nbody_paper_name = "nbody_digits3_len20_size64_r0_train20k"
+nbody_paper_zip_name = "nbody_paper.zip"
+
+def s3_download_nbody_paper(save_dir=None, exist_ok=False):
+    if save_dir is None:
+        from earthformer.config import cfg
+        save_dir = os.path.join(cfg.datasets_dir, "nbody")
+    if os.path.exists(os.path.join(save_dir, nbody_paper_name)) and not exist_ok:
+        warnings.warn(f"N-body dataset {os.path.join(save_dir, nbody_paper_name)} already exists!")
+    else:
+        os.makedirs(save_dir, exist_ok=True)
+        os.system(f"aws s3 cp --no-sign-request s3://deep-earth/experiments/earthformer/nbody/{nbody_paper_zip_name} "
+                  f"{save_dir}")
+        os.system(f"unzip {os.path.join(save_dir, nbody_paper_zip_name)} "
+                  f"-d {save_dir}")
+
+if __name__ == "__main__":
+    s3_download_nbody_paper(exist_ok=False)

--- a/scripts/datasets/nbody/generate_nbody_dataset.py
+++ b/scripts/datasets/nbody/generate_nbody_dataset.py
@@ -29,7 +29,7 @@ def duplicate_single_seq_dataset(npz_path, num_copies=64, save_path=None):
 
 def generate_nbody_dataset(save_dir=None, oc_file_path=None):
     if oc_file_path is None:
-        oc_file_path = os.path.join("..", "scripts", "cfg.yaml")
+        oc_file_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "cfg.yaml")
     dataset_oc = OmegaConf.to_object(OmegaConf.load(open(oc_file_path, "r")).dataset)
     if save_dir is None:
         from earthformer.config import cfg


### PR DESCRIPTION
1. Upload N-body MNIST dataset used in the Earthformer paper to https://deep-earth.s3.amazonaws.com/experiments/earthformer/nbody/nbody_paper.zip.
2. Support downloading via [script](https://github.com/gaozhihan/earth-forecasting-transformer/blob/ab469f83b16edb91df80b028ab39d32baa5591d0/scripts/datasets/nbody/download_nbody_paper.py).