### PR TITLE
fix: delete unused layer `z_proj`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![PWC](https://img.shields.io/endpoint.svg?url=https://paperswithcode.com/badge/earthformer-exploring-space-time-transformers/earth-surface-forecasting-on-earthnet2021-iid)](https://paperswithcode.com/sota/earth-surface-forecasting-on-earthnet2021-iid?p=earthformer-exploring-space-time-transformers)
 [![PWC](https://img.shields.io/endpoint.svg?url=https://paperswithcode.com/badge/earthformer-exploring-space-time-transformers/earth-surface-forecasting-on-earthnet2021-ood)](https://paperswithcode.com/sota/earth-surface-forecasting-on-earthnet2021-ood?p=earthformer-exploring-space-time-transformers)
 
-By [Zhihan Gao](https://scholar.google.com/citations?user=P6ACUAUAAAAJ&hl=zh-CN), [Xingjian Shi](https://github.com/sxjscience), [Hao Wang](http://www.wanghao.in/), [Yi Zhu](https://bryanyzhu.github.io/), [Yuyang Wang](https://scholar.google.com/citations?user=IKUm624AAAAJ&hl=en), [Mu Li](https://github.com/mli), [Dit-Yan Yeung](https://scholar.google.com/citations?user=nEsOOx8AAAAJ&hl=en).
+By [Zhihan Gao](https://scholar.google.com/citations?user=P6ACUAUAAAAJ&hl=en), [Xingjian Shi](https://github.com/sxjscience), [Hao Wang](http://www.wanghao.in/), [Yi Zhu](https://bryanyzhu.github.io/), [Yuyang Wang](https://scholar.google.com/citations?user=IKUm624AAAAJ&hl=en), [Mu Li](https://github.com/mli), [Dit-Yan Yeung](https://scholar.google.com/citations?user=nEsOOx8AAAAJ&hl=en).
 
 This repo is the official implementation of ["Earthformer: Exploring Space-Time Transformers for Earth System Forecasting"](https://www.amazon.science/publications/earthformer-exploring-space-time-transformers-for-earth-system-forecasting) that will appear in NeurIPS 2022. 
 

--- a/src/earthformer/cuboid_transformer/cuboid_transformer_unet_dec.py
+++ b/src/earthformer/cuboid_transformer/cuboid_transformer_unet_dec.py
@@ -703,7 +703,6 @@ class CuboidTransformerAuxModel(nn.Module):
             maxH=H_in, maxW=W_in, maxT=T_in)
         mem_shapes = self.encoder.get_mem_shapes()
 
-        self.z_proj = nn.Linear(mem_shapes[-1][-1], mem_shapes[-1][-1])
         self.dec_pos_embed = PosEmbed(
             embed_dim=mem_shapes[-1][-1], typ=pos_embed_type,
             maxT=T_out, maxH=mem_shapes[-1][1], maxW=mem_shapes[-1][2])
@@ -889,8 +888,6 @@ class CuboidTransformerAuxModel(nn.Module):
         self.enc_pos_embed.reset_parameters()
         self.decoder.reset_parameters()
         self.dec_pos_embed.reset_parameters()
-        apply_initialization(self.z_proj,
-                             linear_mode="0")
 
     def _interp_aux(self, aux_input, ref_shape):
         r"""


### PR DESCRIPTION
1. delete unused layer `z_proj`.
2. deprecate old pretrained weights to https://deep-earth.s3.amazonaws.com/experiments/earthformer/pretrained_checkpoints/_deprecated_z_proj_earthformer_earthnet2021.pt
3. update new pretrained weights using the same url as the previous: https://deep-earth.s3.amazonaws.com/experiments/earthformer/pretrained_checkpoints/earthformer_earthnet2021.pt
