### PR TITLE
misc fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![PWC](https://img.shields.io/endpoint.svg?url=https://paperswithcode.com/badge/earthformer-exploring-space-time-transformers/earth-surface-forecasting-on-earthnet2021-iid)](https://paperswithcode.com/sota/earth-surface-forecasting-on-earthnet2021-iid?p=earthformer-exploring-space-time-transformers)
 [![PWC](https://img.shields.io/endpoint.svg?url=https://paperswithcode.com/badge/earthformer-exploring-space-time-transformers/earth-surface-forecasting-on-earthnet2021-ood)](https://paperswithcode.com/sota/earth-surface-forecasting-on-earthnet2021-ood?p=earthformer-exploring-space-time-transformers)
 
-By [Zhihan Gao](https://scholar.google.com/citations?user=P6ACUAUAAAAJ&hl=zh-CN), [Xingjian Shi](https://github.com/sxjscience), [Hao Wang](http://www.wanghao.in/), [Yi Zhu](https://bryanyzhu.github.io/), [Yuyang Wang](https://scholar.google.com/citations?user=IKUm624AAAAJ&hl=en), [Mu Li](https://github.com/mli), [Dit-Yan Yeung](https://scholar.google.com/citations?user=nEsOOx8AAAAJ&hl=en).
+By [Zhihan Gao](https://scholar.google.com/citations?user=P6ACUAUAAAAJ&hl=en), [Xingjian Shi](https://github.com/sxjscience), [Hao Wang](http://www.wanghao.in/), [Yi Zhu](https://bryanyzhu.github.io/), [Yuyang Wang](https://scholar.google.com/citations?user=IKUm624AAAAJ&hl=en), [Mu Li](https://github.com/mli), [Dit-Yan Yeung](https://scholar.google.com/citations?user=nEsOOx8AAAAJ&hl=en).
 
 This repo is the official implementation of ["Earthformer: Exploring Space-Time Transformers for Earth System Forecasting"](https://www.amazon.science/publications/earthformer-exploring-space-time-transformers-for-earth-system-forecasting) that will appear in NeurIPS 2022. 
 

--- a/src/earthformer/datasets/earthnet/earthnet_toolkit/plot_cube.py
+++ b/src/earthformer/datasets/earthnet/earthnet_toolkit/plot_cube.py
@@ -1,5 +1,6 @@
 """Code is adapted from https://github.com/earthnet2021/earthnet-toolkit."""
-import matplotlib.pyplot as plt 
+import matplotlib.pyplot as plt
+from math import ceil
 import numpy as np
 import matplotlib.colors as clr
 import matplotlib.cm as cm
@@ -68,14 +69,15 @@ def colorize(data, colormap = "ndvi", mask_red = None, mask_blue = None):
 
 def gallery(array, ncols=10):
     nindex, height, width, intensity = array.shape
-    padded = np.zeros((nindex, height + 2, width + 2, intensity))
-    padded[:,1:-1,1:-1,:] = array
-    nindex, height, width, intensity = padded.shape
-    nrows = nindex//ncols
-    assert nindex == nrows*ncols
-    result = (padded.reshape(nrows, ncols, height, width, intensity)
+    nrows = ceil(nindex / ncols)
+    nindex_pad = nrows * ncols
+    height_pad = height + 2
+    width_pad = width + 2
+    padded = np.zeros((nindex_pad, height_pad, width_pad, intensity))
+    padded[:nindex,1:-1,1:-1,:] = array
+    result = (padded.reshape(nrows, ncols, height_pad, width_pad, intensity)
               .swapaxes(1,2)
-              .reshape(height*nrows, width*ncols, intensity))
+              .reshape(height_pad*nrows, width_pad*ncols, intensity))
     return result
 
 def cube_gallery(cube, variable = "rgb", vegetation_mask = None, cloud_mask = True, save_path = None):

--- a/src/earthformer/datasets/earthnet/visualization.py
+++ b/src/earthformer/datasets/earthnet/visualization.py
@@ -63,7 +63,7 @@ def vis_earthnet_seq(
     fontproperties.set_size(font_size)
     # font.set_weight("bold")
 
-    default_layout = "NHWCT"
+    default_layout = "NTHWC"
     data_np_list = []
     label_list = []
     if context_np is not None:
@@ -93,14 +93,6 @@ def vis_earthnet_seq(
         figsize=figsize, dpi=dpi,
         constrained_layout=True)
     for data, label, ax in zip(data_np_list, label_list, axes):
-        hw = 128 if variable in ["rgb", "ndvi"] else 80
-        hw_idxs = [i for i, j in enumerate(data.shape) if j == hw]
-        assert (len(hw_idxs) > 1)
-        if len(hw_idxs) == 2 and hw_idxs != [1, 2]:
-            c_idx = [i for i, j in enumerate(data.shape) if j == min([j for j in data.shape if j != hw])][0]
-            t_idx = [i for i, j in enumerate(data.shape) if j == max([j for j in data.shape if j != hw])][0]
-            data = np.transpose(data, (t_idx, hw_idxs[0], hw_idxs[1], c_idx))
-
         if variable == "rgb":
             targ = np.stack([data[:, :, :, 2], data[:, :, :, 1], data[:, :, :, 0]], axis=-1)
             targ[targ < 0] = 0

--- a/src/earthformer/utils/layout.py
+++ b/src/earthformer/utils/layout.py
@@ -12,7 +12,7 @@ def layout_to_in_out_slice(layout, in_len, out_len=None):
     if out_len is None:
         out_slice[t_axis] = slice(in_len, None)
     else:
-        out_slice[t_axis] = slice(-out_len, None)
+        out_slice[t_axis] = slice(in_len, in_len + out_len)
     return in_slice, out_slice
 
 def change_layout_np(data,


### PR DESCRIPTION
1. [layout manipulation](https://github.com/amazon-science/earth-forecasting-transformer/blob/5dfe20742824cf51b281b0ba4cf41d5e5ebb3320/src/earthformer/datasets/earthnet/visualization.py) in previous [`vis_earthnet_seq`](https://github.com/gaozhihan/earth-forecasting-transformer/blob/78152d6c36288e97f5fa546e5d1becba77310dd9/src/earthformer/datasets/earthnet/visualization.py#L16) adapted from the [official impl](https://github.com/earthnet2021/earthnet-toolkit/blob/448d94fc207a1ed09066b97221599998c2a9b3ae/earthnet/plot_cube.py) is awkward and fails when the `seq_len` is smaller than `channels`, e.g. `seq_len = 1`.
2. Improve the [`gallery()`](https://github.com/amazon-science/earth-forecasting-transformer/blob/5dfe20742824cf51b281b0ba4cf41d5e5ebb3320/src/earthformer/datasets/earthnet/earthnet_toolkit/plot_cube.py#L69) for visualization EarthNet2021 sequences. Enable `seq_len` indivisible by `ncols` by [padding the `seq_len`](https://github.com/gaozhihan/earth-forecasting-transformer/blob/78152d6c36288e97f5fa546e5d1becba77310dd9/src/earthformer/datasets/earthnet/earthnet_toolkit/plot_cube.py#L76).
3. Make `out_seq` adjacent to `in_seq` in [`layout_to_in_out_slice()`](https://github.com/gaozhihan/earth-forecasting-transformer/blob/78152d6c36288e97f5fa546e5d1becba77310dd9/src/earthformer/utils/layout.py#L15).
