### PR TITLE
fix: `seq_len = 1` in N-body MNIST

### DIFF
--- a/src/earthformer/datasets/nbody/nbody_mnist_torch_wrap.py
+++ b/src/earthformer/datasets/nbody/nbody_mnist_torch_wrap.py
@@ -165,8 +165,7 @@ class NBodyMovingMNISTTorchDataset(Dataset):
                                 mode="bicubic",
                                 align_corners=False)
             ret = ret.squeeze(1).unsqueeze(-1)
-        ret[ret > 255.0] = 255.0
-        ret[ret < 0.0] = 0.0
+        ret.clamp_(0.0, 255.0)
         if self.rescale_01:
             ret /= 255.0
         return ret


### PR DESCRIPTION
`.squeeze()` deletes temporal axis when `seq_len = 1`. Fixed by specifying the axis.
