### PR TITLE
fix(cuboid_transformer): Modified the argument order of '_generalize_padding' so that 'pad_h' comes before 'pad_w'.

### DIFF
--- a/src/earthformer/cuboid_transformer/cuboid_transformer.py
+++ b/src/earthformer/cuboid_transformer/cuboid_transformer.py
@@ -277,7 +277,7 @@ class PatchMerging3D(nn.Module):
             T += pad_t
             H += pad_h
             W += pad_w
-            x = _generalize_padding(x, pad_t, pad_w, pad_h, padding_type=self.padding_type)
+            x = _generalize_padding(x, pad_t, pad_h, pad_w, padding_type=self.padding_type)
 
         x = x.reshape((B,
                        T // self.downsample[0], self.downsample[0],


### PR DESCRIPTION
### *Issue:*
In Line 280 of the PatchMerging3D class, the order of the pad_h and pad_w arguments in _generalize_padding is incorrect.
AS-IS: x = _generalize_padding(x, pad_t, pad_w, pad_h, padding_type=self.padding_type)
TO-BE: x = _generalize_padding(x, pad_t, pad_h, pad_w, padding_type=self.padding_type)


### *Description of changes:*
The order of arguments in '_generalize_padding' has been modified so that pad_h comes before pad_w.


--
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
