### PR TITLE
Fix bug in hierarchical pos embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![PWC](https://img.shields.io/endpoint.svg?url=https://paperswithcode.com/badge/earthformer-exploring-space-time-transformers/earth-surface-forecasting-on-earthnet2021-iid)](https://paperswithcode.com/sota/earth-surface-forecasting-on-earthnet2021-iid?p=earthformer-exploring-space-time-transformers)
 [![PWC](https://img.shields.io/endpoint.svg?url=https://paperswithcode.com/badge/earthformer-exploring-space-time-transformers/earth-surface-forecasting-on-earthnet2021-ood)](https://paperswithcode.com/sota/earth-surface-forecasting-on-earthnet2021-ood?p=earthformer-exploring-space-time-transformers)
 
-By [Zhihan Gao](https://scholar.google.com/citations?user=P6ACUAUAAAAJ&hl=zh-CN), [Xingjian Shi](https://github.com/sxjscience), [Hao Wang](http://www.wanghao.in/), [Yi Zhu](https://bryanyzhu.github.io/), [Yuyang Wang](https://scholar.google.com/citations?user=IKUm624AAAAJ&hl=en), [Mu Li](https://github.com/mli), [Dit-Yan Yeung](https://scholar.google.com/citations?user=nEsOOx8AAAAJ&hl=en).
+By [Zhihan Gao](https://scholar.google.com/citations?user=P6ACUAUAAAAJ&hl=en), [Xingjian Shi](https://github.com/sxjscience), [Hao Wang](http://www.wanghao.in/), [Yi Zhu](https://bryanyzhu.github.io/), [Yuyang Wang](https://scholar.google.com/citations?user=IKUm624AAAAJ&hl=en), [Mu Li](https://github.com/mli), [Dit-Yan Yeung](https://scholar.google.com/citations?user=nEsOOx8AAAAJ&hl=en).
 
 This repo is the official implementation of ["Earthformer: Exploring Space-Time Transformers for Earth System Forecasting"](https://www.amazon.science/publications/earthformer-exploring-space-time-transformers-for-earth-system-forecasting) that will appear in NeurIPS 2022. 
 

--- a/src/earthformer/cuboid_transformer/cuboid_transformer.py
+++ b/src/earthformer/cuboid_transformer/cuboid_transformer.py
@@ -2365,7 +2365,7 @@ class CuboidTransformerDecoder(nn.Module):
             if self.hierarchical_pos_embed:
                 self.hierarchical_pos_embed_l = nn.ModuleList([
                     PosEmbed(embed_dim=self.mem_shapes[i][-1], typ=pos_embed_type,
-                             maxT=self.mem_shapes[i][0], maxH=self.mem_shapes[i][1], maxW=self.mem_shapes[i][2])
+                             maxT=target_temporal_length, maxH=self.mem_shapes[i][1], maxW=self.mem_shapes[i][2])
                     for i in range(self.num_blocks - 1)])
 
         self.reset_parameters()


### PR DESCRIPTION
Fix the bug in the hierarchical positional embeddings of the cuboid transformer decoder mentioned by #49:

https://github.com/amazon-science/earth-forecasting-transformer/blob/a9b42c15f8acdbff5df9229f49d70821d227b1d7/src/earthformer/cuboid_transformer/cuboid_transformer.py#L2365-L2369

Setting `maxT=self.mem_shapes[i][0]` leads to error when `T_in < T_out`.
