### PR TITLE
Update docs and S3 urls

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cpu
-        pip install pytorch_lightning>=1.7.4
+        pip install pytorch_lightning==1.6.4
         pip install xarray netcdf4 opencv-python
         pip install -U -e . --no-build-isolation
     - name: Test with pytest

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![PWC](https://img.shields.io/endpoint.svg?url=https://paperswithcode.com/badge/earthformer-exploring-space-time-transformers/earth-surface-forecasting-on-earthnet2021-iid)](https://paperswithcode.com/sota/earth-surface-forecasting-on-earthnet2021-iid?p=earthformer-exploring-space-time-transformers)
 [![PWC](https://img.shields.io/endpoint.svg?url=https://paperswithcode.com/badge/earthformer-exploring-space-time-transformers/earth-surface-forecasting-on-earthnet2021-ood)](https://paperswithcode.com/sota/earth-surface-forecasting-on-earthnet2021-ood?p=earthformer-exploring-space-time-transformers)
 
-By [Zhihan Gao](https://scholar.google.com/citations?user=P6ACUAUAAAAJ&hl=zh-CN), [Xingjian Shi](https://github.com/sxjscience), [Hao Wang](http://www.wanghao.in/), [Yi Zhu](https://bryanyzhu.github.io/), [Yuyang Wang](https://scholar.google.com/citations?user=IKUm624AAAAJ&hl=en), [Mu Li](https://github.com/mli), [Dit-Yan Yeung](https://scholar.google.com/citations?user=nEsOOx8AAAAJ&hl=en).
+By [Zhihan Gao](https://scholar.google.com/citations?user=P6ACUAUAAAAJ&hl=en), [Xingjian Shi](https://github.com/sxjscience), [Hao Wang](http://www.wanghao.in/), [Yi Zhu](https://bryanyzhu.github.io/), [Yuyang Wang](https://scholar.google.com/citations?user=IKUm624AAAAJ&hl=en), [Mu Li](https://github.com/mli), [Dit-Yan Yeung](https://scholar.google.com/citations?user=nEsOOx8AAAAJ&hl=en).
 
 This repo is the official implementation of ["Earthformer: Exploring Space-Time Transformers for Earth System Forecasting"](https://www.amazon.science/publications/earthformer-exploring-space-time-transformers-for-earth-system-forecasting) that will appear in NeurIPS 2022. 
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If you have CUDA 11.7 installed under `/opt/cuda`, run:
 
 ```bash
 python3 -m pip install torch==1.13.1+cu117 torchvision==0.14.1+cu117 -f https://download.pytorch.org/whl/torch_stable.html
-python3 -m pip install pytorch_lightning>=1.9.0
+python3 -m pip install pytorch_lightning==1.6.4
 python3 -m pip install xarray netcdf4 opencv-python earthnet==0.3.9
 cd ROOT_DIR/earth-forecasting-transformer
 python3 -m pip install -U -e . --no-build-isolation

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Lastly, install dependencies. For example, if you have CUDA 11.6 installed under
 
 ```bash
 python3 -m pip install torch==1.12.1+cu116 torchvision==0.13.1+cu116 -f https://download.pytorch.org/whl/torch_stable.html
-python3 -m pip install pytorch_lightning>=1.6.4
+python3 -m pip install pytorch_lightning==1.6.4
 python3 -m pip install xarray netcdf4 opencv-python earthnet==0.3.9
 cd ROOT_DIR/earth-forecasting-transformer
 python3 -m pip install -U -e . --no-build-isolation

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ By [Zhihan Gao](https://scholar.google.com/citations?user=P6ACUAUAAAAJ&hl=en), [
 
 This repo is the official implementation of ["Earthformer: Exploring Space-Time Transformers for Earth System Forecasting"](https://www.amazon.science/publications/earthformer-exploring-space-time-transformers-for-earth-system-forecasting) that will appear in NeurIPS 2022. 
 
-Check our [poster](https://deep-earth.s3.amazonaws.com/papers/earthformer_neurips2022/Earthformer_poster_NeurIPS22.pdf).
+Check our [poster](https://earthformer.s3.amazonaws.com/docs/Earthformer_poster_NeurIPS22.pdf).
 
 ## Tutorials
 
@@ -57,7 +57,7 @@ Lastly, install dependencies. For example, if you have CUDA 11.6 installed under
 ```bash
 python3 -m pip install torch==1.12.1+cu116 torchvision==0.13.1+cu116 -f https://download.pytorch.org/whl/torch_stable.html
 python3 -m pip install pytorch_lightning>=1.6.4
-python3 -m pip install xarray netcdf4 opencv-python
+python3 -m pip install xarray netcdf4 opencv-python earthnet==0.3.9
 cd ROOT_DIR/earth-forecasting-transformer
 python3 -m pip install -U -e . --no-build-isolation
 
@@ -68,9 +68,9 @@ CUDA_HOME=/usr/local/cuda python3 -m pip install -v --no-cache-dir --global-opti
 If you have CUDA 11.7 installed under `/opt/cuda`, run:
 
 ```bash
-python3 -m pip install torch==1.13.0+cu117 torchvision==0.14.0+cu117 -f https://download.pytorch.org/whl/torch_stable.html
-python3 -m pip install pytorch_lightning>=1.7.7 
-python3 -m pip install xarray netcdf4 opencv-python
+python3 -m pip install torch==1.13.1+cu117 torchvision==0.14.1+cu117 -f https://download.pytorch.org/whl/torch_stable.html
+python3 -m pip install pytorch_lightning>=1.9.0
+python3 -m pip install xarray netcdf4 opencv-python earthnet==0.3.9
 cd ROOT_DIR/earth-forecasting-transformer
 python3 -m pip install -U -e . --no-build-isolation
 
@@ -91,7 +91,7 @@ $\frac{d^2\boldsymbol{x}\_{i}}{dt^2} = - \sum\_{j\neq i}\frac{G m\_j (\boldsymbo
 
 where $\boldsymbol{x}\_{i}$ is the spatial coordinates of the $i$-th digit, $G$ is the gravitational constant, $m\_j$ is the mass of the $j$-th digit, $r$ is a constant representing the power scale in the gravitational law, $d\_{\text{soft}}$ is a small softening distance that ensures numerical stability.
 
-The N-body MNIST dataset we used in the paper can be downloaded from https://deep-earth.s3.amazonaws.com/experiments/earthformer/nbody/nbody_paper.zip .
+The N-body MNIST dataset we used in the paper can be downloaded from https://earthformer.s3.amazonaws.com/nbody/nbody_paper.zip .
 
 In addition, you can also use the following script for downloading / extracting the data:
 ```bash
@@ -133,13 +133,16 @@ unzip datasets/enso_round1_train_20210201.zip -d datasets/icar_enso_2021
 
 ### EarthNet2021
 
-You may follow the [official instructions](https://www.earthnet.tech/docs/ds-download/) for downloading [EarthNet2021 dataset](https://www.earthnet.tech/docs/ch-task/). 
+You may follow the [official instructions](https://www.earthnet.tech/en21/ds-download/) for downloading [EarthNet2021 dataset](https://www.earthnet.tech/en21/ch-task/). 
 We recommend download it via the [earthnet_toolket](https://github.com/earthnet2021/earthnet-toolkit).
-
 ```python
-# python3 -m pip install earthnet
 import earthnet as en
-en.Downloader.get("./datasets/earthnet2021", "all")
+en.download(dataset="earthnet2021", splits="all", save_directory="./datasets/earthnet2021")
+```
+Alternatively, you may download [EarthNet2021x dataset](https://www.earthnet.tech/en21x/download/), which is the same as [EarthNet2021 dataset](https://www.earthnet.tech/en21/ch-task/) except for the file format (`.npz` for EarthNet2021 and `.nc` for EarthNet2021x).
+```python
+import earthnet as en
+en.download(dataset="earthnet2021x", splits="all", save_directory="./datasets/earthnet2021x")
 ```
 
 It requires 455G disk space in total.
@@ -157,9 +160,9 @@ Find detailed instructions in how to train the models or running inference with 
 
 | Dataset       | Script Folder                                            | Pretrained Weights                                                                                                     | Config                                                                              |
 |---------------|----------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
-| SEVIR         | [scripts](./scripts/cuboid_transformer/sevir)            | [link](https://deep-earth.s3.amazonaws.com/experiments/earthformer/pretrained_checkpoints/earthformer_sevir.pt)        | [config](./scripts/cuboid_transformer/sevir/earthformer_sevir_v1.yaml)              |
-| ICAR-ENSO     | [scripts](./scripts/cuboid_transformer/enso)             | [link](https://deep-earth.s3.amazonaws.com/experiments/earthformer/pretrained_checkpoints/earthformer_icarenso2021.pt) | [config](./scripts/cuboid_transformer/enso/earthformer_enso_v1.yaml)                |
-| EarthNet2021  | [scripts](./scripts/cuboid_transformer/earthnet_w_meso)  | [link](https://deep-earth.s3.amazonaws.com/experiments/earthformer/pretrained_checkpoints/earthformer_earthnet2021.pt) | [config](./scripts/cuboid_transformer/earthnet_w_meso/earthformer_earthnet_v1.yaml) |
+| SEVIR         | [scripts](./scripts/cuboid_transformer/sevir)            | [link](https://earthformer.s3.amazonaws.com/pretrained_checkpoints/earthformer_sevir.pt)        | [config](./scripts/cuboid_transformer/sevir/earthformer_sevir_v1.yaml)              |
+| ICAR-ENSO     | [scripts](./scripts/cuboid_transformer/enso)             | [link](https://earthformer.s3.amazonaws.com/pretrained_checkpoints/earthformer_icarenso2021.pt) | [config](./scripts/cuboid_transformer/enso/earthformer_enso_v1.yaml)                |
+| EarthNet2021  | [scripts](./scripts/cuboid_transformer/earthnet_w_meso)  | [link](https://earthformer.s3.amazonaws.com/pretrained_checkpoints/earthformer_earthnet2021.pt) | [config](./scripts/cuboid_transformer/earthnet_w_meso/earthformer_earthnet_v1.yaml) |
 | N-body MNIST  | [scripts](./scripts/cuboid_transformer/nbody)            | -                                                                                                                      | -                                                                                   |
 
 ## Citing Earthformer

--- a/scripts/cuboid_transformer/earthnet_w_meso/predict_cuboid_en21x.py
+++ b/scripts/cuboid_transformer/earthnet_w_meso/predict_cuboid_en21x.py
@@ -64,7 +64,7 @@ def main():
         oc_file=config_file
     )
 
-    pretrained_checkpoint_url = "https://deep-earth.s3.amazonaws.com/experiments/earthformer/pretrained_checkpoints/earthformer_earthnet2021.pt"
+    pretrained_checkpoint_url = "https://earthformer.s3.amazonaws.com/pretrained_checkpoints/earthformer_earthnet2021.pt"
     local_checkpoint_path = os.path.join(save_dir, "earthformer_earthnet2021.pt")
     download(url=pretrained_checkpoint_url, path=local_checkpoint_path)
 

--- a/scripts/datasets/nbody/download_nbody_paper.py
+++ b/scripts/datasets/nbody/download_nbody_paper.py
@@ -13,7 +13,7 @@ def s3_download_nbody_paper(save_dir=None, exist_ok=False):
         warnings.warn(f"N-body dataset {os.path.join(save_dir, nbody_paper_name)} already exists!")
     else:
         os.makedirs(save_dir, exist_ok=True)
-        os.system(f"aws s3 cp --no-sign-request s3://deep-earth/experiments/earthformer/nbody/{nbody_paper_zip_name} "
+        os.system(f"aws s3 cp --no-sign-request s3://earthformer/nbody/{nbody_paper_zip_name} "
                   f"{save_dir}")
         os.system(f"unzip {os.path.join(save_dir, nbody_paper_zip_name)} "
                   f"-d {save_dir}")

--- a/src/earthformer/cuboid_transformer/cuboid_transformer.py
+++ b/src/earthformer/cuboid_transformer/cuboid_transformer.py
@@ -2365,7 +2365,7 @@ class CuboidTransformerDecoder(nn.Module):
             if self.hierarchical_pos_embed:
                 self.hierarchical_pos_embed_l = nn.ModuleList([
                     PosEmbed(embed_dim=self.mem_shapes[i][-1], typ=pos_embed_type,
-                             maxT=self.mem_shapes[i][0], maxH=self.mem_shapes[i][1], maxW=self.mem_shapes[i][2])
+                             maxT=target_temporal_length, maxH=self.mem_shapes[i][1], maxW=self.mem_shapes[i][2])
                     for i in range(self.num_blocks - 1)])
 
         self.reset_parameters()

--- a/src/earthformer/utils/checkpoint.py
+++ b/src/earthformer/utils/checkpoint.py
@@ -123,5 +123,5 @@ def s3_download_pretrained_ckpt(ckpt_name, save_dir=None, exist_ok=False):
         warnings.warn(f"Checkpoint file {os.path.join(save_dir, ckpt_name)} already exists!")
     else:
         os.makedirs(save_dir, exist_ok=True)
-        os.system(f"aws s3 cp --no-sign-request s3://deep-earth/experiments/earthformer/pretrained_checkpoints/{ckpt_name} "
+        os.system(f"aws s3 cp --no-sign-request s3://earthformer/pretrained_checkpoints/{ckpt_name} "
                   f"{save_dir}")

--- a/tests/test_cuboid.py
+++ b/tests/test_cuboid.py
@@ -1,0 +1,86 @@
+import torch
+from torch import nn
+from omegaconf import OmegaConf
+from earthformer.cuboid_transformer.cuboid_transformer import CuboidTransformerModel
+import os
+
+
+oc_file = "./scripts/cuboid_transformer/sevir/earthformer_sevir_v1.yaml"
+model_cfg = OmegaConf.to_object(OmegaConf.load(open(oc_file, "r")))
+num_blocks = len(model_cfg["enc_depth"])
+if isinstance(model_cfg["self_pattern"], str):
+    enc_attn_patterns = [model_cfg["self_pattern"]] * num_blocks
+else:
+    enc_attn_patterns = OmegaConf.to_container(model_cfg["self_pattern"])
+if isinstance(model_cfg["cross_self_pattern"], str):
+    dec_self_attn_patterns = [model_cfg["cross_self_pattern"]] * num_blocks
+else:
+    dec_self_attn_patterns = OmegaConf.to_container(model_cfg["cross_self_pattern"])
+if isinstance(model_cfg["cross_pattern"], str):
+    dec_cross_attn_patterns = [model_cfg["cross_pattern"]] * num_blocks
+else:
+    dec_cross_attn_patterns = OmegaConf.to_container(model_cfg["cross_pattern"])
+
+model = CuboidTransformerModel(
+            input_shape=model_cfg["input_shape"],
+            target_shape=model_cfg["target_shape"],
+            base_units=model_cfg["base_units"],
+            block_units=model_cfg["block_units"],
+            scale_alpha=model_cfg["scale_alpha"],
+            enc_depth=model_cfg["enc_depth"],
+            dec_depth=model_cfg["dec_depth"],
+            enc_use_inter_ffn=model_cfg["enc_use_inter_ffn"],
+            dec_use_inter_ffn=model_cfg["dec_use_inter_ffn"],
+            dec_hierarchical_pos_embed=model_cfg["dec_hierarchical_pos_embed"],
+            downsample=model_cfg["downsample"],
+            downsample_type=model_cfg["downsample_type"],
+            enc_attn_patterns=enc_attn_patterns,
+            dec_self_attn_patterns=dec_self_attn_patterns,
+            dec_cross_attn_patterns=dec_cross_attn_patterns,
+            dec_cross_last_n_frames=model_cfg["dec_cross_last_n_frames"],
+            dec_use_first_self_attn=model_cfg["dec_use_first_self_attn"],
+            num_heads=model_cfg["num_heads"],
+            attn_drop=model_cfg["attn_drop"],
+            proj_drop=model_cfg["proj_drop"],
+            ffn_drop=model_cfg["ffn_drop"],
+            upsample_type=model_cfg["upsample_type"],
+            ffn_activation=model_cfg["ffn_activation"],
+            gated_ffn=model_cfg["gated_ffn"],
+            norm_layer=model_cfg["norm_layer"],
+            # global vectors
+            num_global_vectors=model_cfg["num_global_vectors"],
+            use_dec_self_global=model_cfg["use_dec_self_global"],
+            dec_self_update_global=model_cfg["dec_self_update_global"],
+            use_dec_cross_global=model_cfg["use_dec_cross_global"],
+            use_global_vector_ffn=model_cfg["use_global_vector_ffn"],
+            use_global_self_attn=model_cfg["use_global_self_attn"],
+            separate_global_qkv=model_cfg["separate_global_qkv"],
+            global_dim_ratio=model_cfg["global_dim_ratio"],
+            # initial_downsample
+            initial_downsample_type=model_cfg["initial_downsample_type"],
+            initial_downsample_activation=model_cfg["initial_downsample_activation"],
+            # initial_downsample_type=="conv"
+            initial_downsample_scale=model_cfg["initial_downsample_scale"],
+            initial_downsample_conv_layers=model_cfg["initial_downsample_conv_layers"],
+            final_upsample_conv_layers=model_cfg["final_upsample_conv_layers"],
+            # misc
+            padding_type=model_cfg["padding_type"],
+            z_init_method=model_cfg["z_init_method"],
+            checkpoint_level=model_cfg["checkpoint_level"],
+            pos_embed_type=model_cfg["pos_embed_type"],
+            use_relative_pos=model_cfg["use_relative_pos"],
+            self_attn_use_final_proj=model_cfg["self_attn_use_final_proj"],
+            # initialization
+            attn_linear_init_mode=model_cfg["attn_linear_init_mode"],
+            ffn_linear_init_mode=model_cfg["ffn_linear_init_mode"],
+            conv_init_mode=model_cfg["conv_init_mode"],
+            down_up_linear_init_mode=model_cfg["down_up_linear_init_mode"],
+            norm_init_mode=model_cfg["norm_init_mode"],
+        )
+
+input_shape = model_cfg["input_shape"]
+target_shape = model_cfg["target_shape"]
+batch_size = 2
+data = torch.rand((batch_size, *input_shape))
+out = model(data)
+print(out.shape)

--- a/tests/test_cuboid.py
+++ b/tests/test_cuboid.py
@@ -6,7 +6,7 @@ import os
 
 
 oc_file = "./scripts/cuboid_transformer/sevir/earthformer_sevir_v1.yaml"
-model_cfg = OmegaConf.to_object(OmegaConf.load(open(oc_file, "r")))
+model_cfg = OmegaConf.to_object(OmegaConf.load(open(oc_file, "r")).model)
 num_blocks = len(model_cfg["enc_depth"])
 if isinstance(model_cfg["self_pattern"], str):
     enc_attn_patterns = [model_cfg["self_pattern"]] * num_blocks
@@ -22,61 +22,62 @@ else:
     dec_cross_attn_patterns = OmegaConf.to_container(model_cfg["cross_pattern"])
 
 model = CuboidTransformerModel(
-            input_shape=model_cfg["input_shape"],
-            target_shape=model_cfg["target_shape"],
-            base_units=model_cfg["base_units"],
-            block_units=model_cfg["block_units"],
-            scale_alpha=model_cfg["scale_alpha"],
-            enc_depth=model_cfg["enc_depth"],
-            dec_depth=model_cfg["dec_depth"],
-            enc_use_inter_ffn=model_cfg["enc_use_inter_ffn"],
-            dec_use_inter_ffn=model_cfg["dec_use_inter_ffn"],
-            dec_hierarchical_pos_embed=model_cfg["dec_hierarchical_pos_embed"],
-            downsample=model_cfg["downsample"],
-            downsample_type=model_cfg["downsample_type"],
-            enc_attn_patterns=enc_attn_patterns,
-            dec_self_attn_patterns=dec_self_attn_patterns,
-            dec_cross_attn_patterns=dec_cross_attn_patterns,
-            dec_cross_last_n_frames=model_cfg["dec_cross_last_n_frames"],
-            dec_use_first_self_attn=model_cfg["dec_use_first_self_attn"],
-            num_heads=model_cfg["num_heads"],
-            attn_drop=model_cfg["attn_drop"],
-            proj_drop=model_cfg["proj_drop"],
-            ffn_drop=model_cfg["ffn_drop"],
-            upsample_type=model_cfg["upsample_type"],
-            ffn_activation=model_cfg["ffn_activation"],
-            gated_ffn=model_cfg["gated_ffn"],
-            norm_layer=model_cfg["norm_layer"],
-            # global vectors
-            num_global_vectors=model_cfg["num_global_vectors"],
-            use_dec_self_global=model_cfg["use_dec_self_global"],
-            dec_self_update_global=model_cfg["dec_self_update_global"],
-            use_dec_cross_global=model_cfg["use_dec_cross_global"],
-            use_global_vector_ffn=model_cfg["use_global_vector_ffn"],
-            use_global_self_attn=model_cfg["use_global_self_attn"],
-            separate_global_qkv=model_cfg["separate_global_qkv"],
-            global_dim_ratio=model_cfg["global_dim_ratio"],
-            # initial_downsample
-            initial_downsample_type=model_cfg["initial_downsample_type"],
-            initial_downsample_activation=model_cfg["initial_downsample_activation"],
-            # initial_downsample_type=="conv"
-            initial_downsample_scale=model_cfg["initial_downsample_scale"],
-            initial_downsample_conv_layers=model_cfg["initial_downsample_conv_layers"],
-            final_upsample_conv_layers=model_cfg["final_upsample_conv_layers"],
-            # misc
-            padding_type=model_cfg["padding_type"],
-            z_init_method=model_cfg["z_init_method"],
-            checkpoint_level=model_cfg["checkpoint_level"],
-            pos_embed_type=model_cfg["pos_embed_type"],
-            use_relative_pos=model_cfg["use_relative_pos"],
-            self_attn_use_final_proj=model_cfg["self_attn_use_final_proj"],
-            # initialization
-            attn_linear_init_mode=model_cfg["attn_linear_init_mode"],
-            ffn_linear_init_mode=model_cfg["ffn_linear_init_mode"],
-            conv_init_mode=model_cfg["conv_init_mode"],
-            down_up_linear_init_mode=model_cfg["down_up_linear_init_mode"],
-            norm_init_mode=model_cfg["norm_init_mode"],
-        )
+    input_shape=model_cfg["input_shape"],
+    target_shape=model_cfg["target_shape"],
+    base_units=model_cfg["base_units"],
+    # block_units=model_cfg["block_units"],
+    scale_alpha=model_cfg["scale_alpha"],
+    enc_depth=model_cfg["enc_depth"],
+    dec_depth=model_cfg["dec_depth"],
+    enc_use_inter_ffn=model_cfg["enc_use_inter_ffn"],
+    dec_use_inter_ffn=model_cfg["dec_use_inter_ffn"],
+    dec_hierarchical_pos_embed=model_cfg["dec_hierarchical_pos_embed"],
+    downsample=model_cfg["downsample"],
+    downsample_type=model_cfg["downsample_type"],
+    enc_attn_patterns=enc_attn_patterns,
+    dec_self_attn_patterns=dec_self_attn_patterns,
+    dec_cross_attn_patterns=dec_cross_attn_patterns,
+    dec_cross_last_n_frames=model_cfg["dec_cross_last_n_frames"],
+    dec_use_first_self_attn=model_cfg["dec_use_first_self_attn"],
+    num_heads=model_cfg["num_heads"],
+    attn_drop=model_cfg["attn_drop"],
+    proj_drop=model_cfg["proj_drop"],
+    ffn_drop=model_cfg["ffn_drop"],
+    upsample_type=model_cfg["upsample_type"],
+    ffn_activation=model_cfg["ffn_activation"],
+    gated_ffn=model_cfg["gated_ffn"],
+    norm_layer=model_cfg["norm_layer"],
+    # global vectors
+    num_global_vectors=model_cfg["num_global_vectors"],
+    use_dec_self_global=model_cfg["use_dec_self_global"],
+    dec_self_update_global=model_cfg["dec_self_update_global"],
+    use_dec_cross_global=model_cfg["use_dec_cross_global"],
+    use_global_vector_ffn=model_cfg["use_global_vector_ffn"],
+    use_global_self_attn=model_cfg["use_global_self_attn"],
+    separate_global_qkv=model_cfg["separate_global_qkv"],
+    global_dim_ratio=model_cfg["global_dim_ratio"],
+    # initial_downsample
+    initial_downsample_type=model_cfg["initial_downsample_type"],
+    initial_downsample_activation=model_cfg["initial_downsample_activation"],
+    # initial_downsample_type=="stack_conv"
+    initial_downsample_stack_conv_num_layers=model_cfg["initial_downsample_stack_conv_num_layers"],
+    initial_downsample_stack_conv_dim_list=model_cfg["initial_downsample_stack_conv_dim_list"],
+    initial_downsample_stack_conv_downscale_list=model_cfg["initial_downsample_stack_conv_downscale_list"],
+    initial_downsample_stack_conv_num_conv_list=model_cfg["initial_downsample_stack_conv_num_conv_list"],
+    # misc
+    padding_type=model_cfg["padding_type"],
+    z_init_method=model_cfg["z_init_method"],
+    checkpoint_level=model_cfg["checkpoint_level"],
+    pos_embed_type=model_cfg["pos_embed_type"],
+    use_relative_pos=model_cfg["use_relative_pos"],
+    self_attn_use_final_proj=model_cfg["self_attn_use_final_proj"],
+    # initialization
+    attn_linear_init_mode=model_cfg["attn_linear_init_mode"],
+    ffn_linear_init_mode=model_cfg["ffn_linear_init_mode"],
+    conv_init_mode=model_cfg["conv_init_mode"],
+    down_up_linear_init_mode=model_cfg["down_up_linear_init_mode"],
+    norm_init_mode=model_cfg["norm_init_mode"],
+)
 
 input_shape = model_cfg["input_shape"]
 target_shape = model_cfg["target_shape"]

--- a/tests/unittests/test_pretrained_checkpoints.py
+++ b/tests/unittests/test_pretrained_checkpoints.py
@@ -22,7 +22,7 @@ def s3_download_unittest_data(data_name):
     test_data_path = os.path.join(test_data_dir, data_name)
     if not os.path.exists(test_data_path):
         os.makedirs(test_data_dir, exist_ok=True)
-        download(url=f"s3://deep-earth/experiments/earthformer/unittests/{data_name}", path=test_data_path)
+        download(url=f"s3://earthformer/unittests/{data_name}", path=test_data_path)
 
 
 def config_cuboid_transformer(cfg, model_type="CuboidTransformerModel"):


### PR DESCRIPTION
1. Fix the installation instructions on [PyTorch Lightning](https://www.pytorchlightning.ai/index.html) by enforcing `pytorch_lightning==1.6.4` to avoid failures in unittests.
2. Update S3 URLs for downloading pretrained weights, poster, data, etc.
